### PR TITLE
Fix Uncaught TypeError in _animationEnd() when _toIconId is empty

### DIFF
--- a/source/js/svg-morpheus.js
+++ b/source/js/svg-morpheus.js
@@ -52,7 +52,8 @@ function SVGMorpheus(element, options, callback) {
     if(progress<1) {
       that._rafid=_reqAnimFrame(that._fnTick);
     } else {
-      that._animationEnd();
+      if (that._toIconId != '')
+        that._animationEnd();
     }
   };
 


### PR DESCRIPTION
I found in my testing that `_animationEnd()` is sometimes called with empty `_toIconId`, resulting in Uncaught TypeError at line:
`if(!!this._icons[this._toIconId].items[i]) {`